### PR TITLE
fix: Remove internal flag _skip_validation from snipe data during con…

### DIFF
--- a/config.py
+++ b/config.py
@@ -159,6 +159,9 @@ class ConfigManager:
                 snipe_data = data.get('snipe', {})
                 notifications_data = data.get('notifications', {})
                 
+                # Remove _skip_validation from snipe_data if present
+                snipe_data.pop('_skip_validation', None)
+                
                 self.config = AppConfig(
                     proxy=ProxyConfig(**proxy_data),
                     discord=DiscordConfig(**discord_data),
@@ -180,6 +183,10 @@ class ConfigManager:
         """Save current configuration to file"""
         try:
             config_dict = asdict(self.config)
+            # Remove internal flags that shouldn't be saved
+            if 'snipe' in config_dict and '_skip_validation' in config_dict['snipe']:
+                del config_dict['snipe']['_skip_validation']
+            
             with open(self.config_path, 'w', encoding='utf-8') as f:
                 yaml.dump(config_dict, f, default_flow_style=False, indent=2)
         except Exception as e:


### PR DESCRIPTION
Application crashed with "got multiple values for keyword argument '_skip_validation'" when loading config.yaml, preventing bearer token testing.

<img width="749" height="69" alt="Screenshot from 2025-10-16 12-43-51" src="https://github.com/user-attachments/assets/e0913216-271d-46bf-be70-03e80692d7f2" />

closes #1
